### PR TITLE
Update "azurerm_key_vault_secret" property

### DIFF
--- a/Terraform/01_Deployment/createEnvironment.tf
+++ b/Terraform/01_Deployment/createEnvironment.tf
@@ -3,7 +3,7 @@
 # Azure Key Vault data source to access local admin password
 data "azurerm_key_vault_secret" "mySecret" {
   name      = "labuser"
-  vault_uri = "https://yourKeyVault.vault.azure.net/"
+  key_vault_id = "/subscriptions/GUID/resourceGroups/RGName/providers/Microsoft.KeyVault/vaults/VaultName"
 }
 
 # get my external IP address to enter into NSG rule


### PR DESCRIPTION
"vault_uri" has been deprecated and is being replaced with the key_vault_id property. 

This change prevents a bugs as described in https://github.com/terraform-providers/terraform-provider-azurerm/issues/2396 

"vault_uri" will be removed in version 2.0 of the provider